### PR TITLE
Fix sequelize console noise

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -3,6 +3,7 @@ const Sequelize = require('sequelize');
 const sequelize = new Sequelize('database', 'username', 'password', {
   dialect: 'sqlite',
   logging: false,
+  operatorsAliases: false
 });
 
 const CREATE_LIKES_QUERY = `CREATE TABLE likes(


### PR DESCRIPTION
Hi Apollo team! I just went through this workshop with you all at React EU, noticed this noise in the console and found a way to fix it. This change silences that annoying sequelize error from the Glitch (or other) console:
```
Thu, 17 May 2018 08:49:41 GMT sequelize deprecated String based operators are now deprecated. Please use Symbol based operators for better security, read more at http://docs.sequelizejs.com/manual/tutorial/querying.html#operators at ../rbd/pnpm-volume/891a944f-cd2a-4c3a-9234-516af8ada535/node_modules/.registry.npmjs.org/sequelize/4.37.7/node_modules/sequelize/lib/sequelize.js:242:13
```
Read more here: 
* https://github.com/sequelize/sequelize/issues/8417#issuecomment-341617577
* http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases

Glitch console before change (on every update!):
<img width="1279" alt="screenshot 2018-05-17 10 54 59" src="https://user-images.githubusercontent.com/159370/40167255-e4ceee2c-59c0-11e8-9727-41f9110a427c.png">

And after:
<img width="1274" alt="screenshot 2018-05-17 10 55 06" src="https://user-images.githubusercontent.com/159370/40167261-e8a9aca8-59c0-11e8-9724-bc7dfbb58be0.png">
